### PR TITLE
fix(android): Add permission and queries to AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,12 @@
 
   <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="com.getcapacitor.community.speechrecognition.speechrecognition">
+
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <queries>
+      <intent>
+        <action android:name="android.speech.RecognitionService" />
+      </intent>
+    </queries>
   </manifest>
   


### PR DESCRIPTION
so users don't have to manually add them
Android Studio manifest merger will merge plugins permissions/queries into the user app

closes https://github.com/capacitor-community/speech-recognition/issues/24
closes https://github.com/capacitor-community/speech-recognition/issues/21