### PR TITLE
fix(android)!: correct handling of partial results

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/speechrecognition/SpeechRecognition.java
+++ b/android/src/main/java/com/getcapacitor/community/speechrecognition/SpeechRecognition.java
@@ -276,9 +276,6 @@ public class SpeechRecognition extends Plugin implements Constants {
             speechRecognizer.setRecognitionListener(listener);
             speechRecognizer.startListening(intent);
             SpeechRecognition.this.listening(true);
-            if (partialResults) {
-              call.resolve();
-            }
           } catch (Exception ex) {
             call.reject(ex.getMessage());
           } finally {
@@ -353,7 +350,7 @@ public class SpeechRecognition extends Plugin implements Constants {
       try {
         JSArray jsArray = new JSArray(matches);
 
-        if (this.call != null && !this.partialResults) {
+        if (this.call != null) {
           this.call.resolve(
               new JSObject().put("status", "success").put("matches", jsArray)
             );


### PR DESCRIPTION
Android stops recognition automatically, so the start promise should be resolved on the results event even if partialResults are activated. 

This should fix #58  and parts of #43 

An alternative approach could be to also pass through the results event, sth like: `notifyListeners("results", ret);`

Long term it could also be nice to include `EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS` as param, though I think that would require more changes. 