### PR TITLE
feat(punctuation): handle punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ SpeechRecognition.available();
  *        prompt - prompt message to display on popup (Android only)
  *        partialResults - return partial results if found
  *        popup - display popup window when listening for utterance (Android only)
+ *        addPunctuation - enable punctuation (IOS only for now)
  * If partialResults is true, the function respond directly without result and event `partialResults` will be emit for each partial result, until stopped.
  * @returns void
  */
@@ -85,6 +86,7 @@ SpeechRecognition.start({
   prompt: "Say something",
   partialResults: true,
   popup: true,
+  addPunctuation: true,
 });
 // listen to partial results
 SpeechRecognition.addListener("partialResults", (data: any) => {

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -56,6 +56,7 @@ public class SpeechRecognition: CAPPlugin {
             let language: String = call.getString("language") ?? "en-US"
             let maxResults : Int = call.getInt("maxResults") ?? self.DEFAULT_MATCHES
             let partialResults : Bool = call.getBool("partialResults") ?? false
+            let addPunctuation : Bool = call.getBool("addPunctuation") ?? false
 
             if (self.recognitionTask != nil) {
                 self.recognitionTask?.cancel()
@@ -77,6 +78,10 @@ public class SpeechRecognition: CAPPlugin {
             self.recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
             self.recognitionRequest?.shouldReportPartialResults = partialResults
 
+            if #available(iOS 16.0, *) {
+                self.recognitionRequest?.addsPunctuation = addPunctuation
+            }
+            
             let inputNode: AVAudioInputNode = self.audioEngine!.inputNode
             let format: AVAudioFormat = inputNode.outputFormat(forBus: 0)
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -65,4 +65,5 @@ export interface UtteranceOptions {
   prompt?: string;
   popup?: boolean;
   partialResults?: boolean;
+  addPunctuation?: boolean;
 }


### PR DESCRIPTION
Feature described on #73.

Add an option to enable/handle punctuation.
For IOS this feature is only available from IOS 16, the validation for that is handled in the PR.