### PR TITLE
docs: getSupportedLanguages not working on Android 13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ SpeechRecognition.stop();
 
 /**
  * This method will return list of languages supported by the speech recognizer.
+ *
+ * It's not available on Android 13 and newer.
+ *
  * @param none
  * @returns languages - array string of languages
  */

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -17,6 +17,14 @@ export interface SpeechRecognitionPlugin {
   available(): Promise<{ available: boolean }>;
   start(options?: UtteranceOptions): Promise<{ matches: string[] }>;
   stop(): Promise<void>;
+  /**
+   * This method will return list of languages supported by the speech recognizer.
+   *
+   * It's not available on Android 13 and newer.
+   *
+   * @param none
+   * @returns languages - array string of languages
+   */
   getSupportedLanguages(): Promise<{ languages: any[] }>;
   /**
    * @deprecated use `checkPermissions()`


### PR DESCRIPTION
document that getSupportedLanguages doesn't work on Android 13 or newer

closes https://github.com/capacitor-community/speech-recognition/issues/70