### PR TITLE
fix!: use correct name on rollup

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ export default {
     {
       file: 'dist/plugin.js',
       format: 'iife',
-      name: 'capacitorPrivacyScreen',
+      name: 'capacitorSpeechRecognition',
       globals: {
         '@capacitor/core': 'capacitorExports',
       },


### PR DESCRIPTION
technically breaking since the name changes