### PR TITLE
feat!: Remove deprecated permission methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ No further action required.
 * [`start(...)`](#start)
 * [`stop()`](#stop)
 * [`getSupportedLanguages()`](#getsupportedlanguages)
-* [`hasPermission()`](#haspermission)
 * [`isListening()`](#islistening)
-* [`requestPermission()`](#requestpermission)
 * [`checkPermissions()`](#checkpermissions)
 * [`requestPermissions()`](#requestpermissions)
 * [`addListener('partialResults', ...)`](#addlistenerpartialresults-)
@@ -160,19 +158,6 @@ It's not available on Android 13 and newer.
 --------------------
 
 
-### hasPermission()
-
-```typescript
-hasPermission() => Promise<{ permission: boolean; }>
-```
-
-This method will check for audio permissions.
-
-**Returns:** <code>Promise&lt;{ permission: boolean; }&gt;</code>
-
---------------------
-
-
 ### isListening()
 
 ```typescript
@@ -184,17 +169,6 @@ This method will check if speech recognition is listening.
 **Returns:** <code>Promise&lt;{ listening: boolean; }&gt;</code>
 
 **Since:** 5.1.0
-
---------------------
-
-
-### requestPermission()
-
-```typescript
-requestPermission() => Promise<void>
-```
-
-This method will prompt the user for audio permission.
 
 --------------------
 

--- a/android/src/main/java/com/getcapacitor/community/speechrecognition/SpeechRecognition.java
+++ b/android/src/main/java/com/getcapacitor/community/speechrecognition/SpeechRecognition.java
@@ -115,25 +115,8 @@ public class SpeechRecognition extends Plugin implements Constants {
     }
 
     @PluginMethod
-    public void hasPermission(PluginCall call) {
-        call.resolve(new JSObject().put("permission", hasAudioPermissions(RECORD_AUDIO_PERMISSION)));
-    }
-
-    @PluginMethod
     public void isListening(PluginCall call) {
         call.resolve(new JSObject().put("listening", SpeechRecognition.this.listening));
-    }
-
-    @PluginMethod
-    public void requestPermission(PluginCall call) {
-        if (!hasAudioPermissions(RECORD_AUDIO_PERMISSION)) {
-            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
-                bridge.getActivity().requestPermissions(new String[] { RECORD_AUDIO_PERMISSION }, REQUEST_CODE_PERMISSION);
-                call.resolve();
-            } else {
-                call.resolve();
-            }
-        }
     }
 
     @ActivityCallback

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -164,24 +164,6 @@ public class SpeechRecognition: CAPPlugin {
         ])
     }
 
-    @objc func hasPermission(_ call: CAPPluginCall) {
-        let status: SFSpeechRecognizerAuthorizationStatus = SFSpeechRecognizer.authorizationStatus()
-        let speechAuthGranted: Bool = (status == SFSpeechRecognizerAuthorizationStatus.authorized)
-
-        if !speechAuthGranted {
-            call.resolve([
-                "permission": false
-            ])
-            return
-        }
-
-        AVAudioSession.sharedInstance().requestRecordPermission { (granted: Bool) in
-            call.resolve([
-                "permission": granted
-            ])
-        }
-    }
-
     @objc override public func checkPermissions(_ call: CAPPluginCall) {
         let status: SFSpeechRecognizerAuthorizationStatus = SFSpeechRecognizer.authorizationStatus()
         let permission: String
@@ -196,48 +178,6 @@ public class SpeechRecognition: CAPPlugin {
             permission = "prompt"
         }
         call.resolve(["speechRecognition": permission])
-    }
-
-    @objc func requestPermission(_ call: CAPPluginCall) {
-        SFSpeechRecognizer.requestAuthorization { (status: SFSpeechRecognizerAuthorizationStatus) in
-            DispatchQueue.main.async {
-                var speechAuthGranted: Bool = false
-
-                switch status {
-                case SFSpeechRecognizerAuthorizationStatus.authorized:
-                    speechAuthGranted = true
-                    break
-
-                case SFSpeechRecognizerAuthorizationStatus.denied:
-                    call.reject(self.messageAccessDenied)
-                    break
-
-                case SFSpeechRecognizerAuthorizationStatus.restricted:
-                    call.reject(self.messageRestricted)
-                    break
-
-                case SFSpeechRecognizerAuthorizationStatus.notDetermined:
-                    call.reject(self.messageNotDetermined)
-                    break
-
-                @unknown default:
-                    call.reject(self.messageUnknown)
-                }
-
-                if !speechAuthGranted {
-                    return
-                }
-
-                AVAudioSession.sharedInstance().requestRecordPermission { (granted: Bool) in
-                    if granted {
-                        call.resolve()
-                    } else {
-                        call.reject(self.messageAccessDeniedMicrophone)
-                    }
-                }
-            }
-
-        }
     }
 
     @objc override public func requestPermissions(_ call: CAPPluginCall) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -46,15 +46,6 @@ export interface SpeechRecognitionPlugin {
    */
   getSupportedLanguages(): Promise<{ languages: any[] }>;
   /**
-   * This method will check for audio permissions.
-   * @param none
-   * @returns permission - boolean true/false if permissions are granted
-   *
-   * @deprecated use `checkPermissions()`
-   */
-  hasPermission(): Promise<{ permission: boolean }>;
-
-  /**
    * This method will check if speech recognition is listening.
    * @param none
    * @returns boolean true/false if speech recognition is currently listening
@@ -62,14 +53,6 @@ export interface SpeechRecognitionPlugin {
    * @since 5.1.0
    */
   isListening(): Promise<{ listening: boolean }>;
-  /**
-   * This method will prompt the user for audio permission.
-   * @param none
-   * @returns void
-   *
-   * @deprecated use `requestPermissions()`
-   */
-  requestPermission(): Promise<void>;
   /**
    * Check the speech recognition permission.
    *


### PR DESCRIPTION
use `checkPermissions()` instead of `hasPermission`
use `requestPermissions()` instead of `requestPermission()`