### PR TITLE
Fix - unexpectedly found nil while unwrapping an optional value

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -72,13 +72,14 @@ public class SpeechRecognition: CAPPlugin {
 
             }
 
-            self.recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
-            self.recognitionRequest?.shouldReportPartialResults = partialResults
+            let recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+            recognitionRequest.shouldReportPartialResults = partialResults
+            self.recognitionRequest = recognitionRequest
 
             let inputNode: AVAudioInputNode = self.audioEngine!.inputNode
             let format: AVAudioFormat = inputNode.outputFormat(forBus: 0)
 
-            self.recognitionTask = self.speechRecognizer?.recognitionTask(with: self.recognitionRequest!, resultHandler: { (result, error) in
+            self.recognitionTask = self.speechRecognizer?.recognitionTask(with: recognitionRequest, resultHandler: { (result, error) in
                 if result != nil {
                     let resultArray: NSMutableArray = NSMutableArray()
                     var counter: Int = 0


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.

This fixes an issue I started seeing when doing speech recognition twice. The second time I called `start`, I got this error and my app would crash. 
