### PR TITLE
Fix: gracefully handle AVAudioSession conflict when mic is busy

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -67,7 +67,12 @@ public class SpeechRecognition: CAPPlugin {
             do {
                 try audioSession.setCategory(AVAudioSession.Category.playAndRecord, options: AVAudioSession.CategoryOptions.defaultToSpeaker)
                 try audioSession.setMode(AVAudioSession.Mode.default)
-                try audioSession.setActive(true, options: AVAudioSession.SetActiveOptions.notifyOthersOnDeactivation)
+                do {
+                    try audioSession.setActive(true, options: AVAudioSession.SetActiveOptions.notifyOthersOnDeactivation)
+                } catch {
+                      call.reject("Microphone is already in use by another application.")
+                      return
+                }
             } catch {
 
             }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.

This PR wraps audioSession.setActive() inside do-catch to avoid fatal crashes when another app holds exclusive microphone access (e.g. Google Meet, FaceTime).
Instead of crashing, the plugin now returns a proper rejection to allow apps to handle the error gracefully.
