### PR TITLE
Fix SpeechRecognizer error handling for "ERROR_SERVER_DISCONNECTED" in Android

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/speechrecognition/SpeechRecognition.java
+++ b/android/src/main/java/com/getcapacitor/community/speechrecognition/SpeechRecognition.java
@@ -5,8 +5,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
 import android.speech.RecognitionListener;
 import android.speech.RecognizerIntent;
 import android.speech.SpeechRecognizer;


### PR DESCRIPTION
Fixes #124 

Added methods to manage SpeechRecognizer lifecycle.

Added new error key `ERROR_SERVER_DISCONNECTED` to `getErrorText` cases.

**Normal flow:** Reuse the same SpeechRecognizer instance (just cancel any pending work and set a new listener)

**After error:** The onError handler destroys and nullifies the recognizer synchronously, so the next start() will create a fresh one

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.

**Note:** I used AI agents (1. GPT-5.1-Codex 2. Gemini 3 Pro, 3. Claude Opus 4.5) with caution to debug/review this issue but still needs a precise review of you maintainer guys :D
@priyankpat @mrbatista